### PR TITLE
Minor documentation updates

### DIFF
--- a/content/en/architecture/component-overview.md
+++ b/content/en/architecture/component-overview.md
@@ -14,11 +14,11 @@ toc: true
 
 ## CoAP Gateway
 
-The CoAP gateway acts act as a CoAP Client, communicating with IoT devices - CoAP Servers following the [OCF specification](https://openconnectivity.org/developer/specifications/). As the component diagram describes, responsibilities of the gateway are:
+The CoAP gateway acts as a CoAP Client, communicating with IoT devices - CoAP Servers following the [OCF specification](https://openconnectivity.org/developer/specifications/). As the component diagram describes, the responsibilities of the gateway are:
 
 - handle and maintain TCP connections coming from devices
-- forward [authentication and authorization requests (see 5.5.5)](https://openconnectivity.org/specs/OCF_Device_To_Cloud_Services_Specification_v2.2.1.pdf#page=15)  to the Authorization Service
-- process device CRUDN operations which are by its nature forwarded to the [Resource Aggregate](#resource-aggregate) or [Resource Directory](#resource-directory)
+- forward [authentication and authorization requests (see 5.5.5)](https://openconnectivity.org/specs/OCF_Device_To_Cloud_Services_Specification_v2.2.1.pdf#page=15) to the Authorization Service
+- process device CRUDN operations, which are by its nature forwarded to the [Resource Aggregate](#resource-aggregate) or [Resource Directory](#resource-directory)
 
 ![L3](/images/diagrams/component-coapgateway.svg "medium-zoom-image")
 
@@ -39,7 +39,7 @@ hide footbox
 
 participant D as "Device"
 participant CGW as "CoAP Gateway"
-participant AS as "Authorization Server"
+participant IS as "Identity Server"
 participant OBT as "Onboarding Tool"
 
 OBT -->[: Discover devices
@@ -59,7 +59,7 @@ D -> CGW ++: Establish TCP connection
 @enduml
 {{< /plantuml >}}
 
-TCP connection which device established to the CoAP Gateway is now authenticated but not authorized. Before the devices becomes reachable, TCP connection needs to be authorized. As this flow describes operation of a new device, device needs within the first connection Sign Up - [register with the plgd.cloud (see 8.1.4)](https://openconnectivity.org/specs/OCF_Device_To_Cloud_Services_Specification_v2.2.1.pdf#page=33). The [authorization code](https://tools.ietf.org/html/rfc6749#section-4.1) received during the OCF Cloud Provisioning process described in the diagram above is be by the CoAP Gateway exchanged for an access and refresh token and returned back to the device. This process is in more detail described in the [OCF Cloud Security Specification (see 6.2)](https://openconnectivity.org/specs/OCF_Cloud_Security_Specification_v2.2.1.pdf#page=12).
+The TCP connection which the device established to the CoAP Gateway is now authenticated, but not authorized. Before the device becomes reachable, the TCP connection needs to be authorized. As this flow describes operation of a new device, device needs within the first connection Sign Up - [register with the plgd.cloud (see 8.1.4)](https://openconnectivity.org/specs/OCF_Device_To_Cloud_Services_Specification_v2.2.1.pdf#page=33). The [authorization code](https://tools.ietf.org/html/rfc6749#section-4.1) received during the OCF Cloud Provisioning process described in the diagram above is exchanged by the CoAP Gateway for an access and refresh token and returned to the device. This process is in more detail described in the [OCF Cloud Security Specification (see 6.2)](https://openconnectivity.org/specs/OCF_Cloud_Security_Specification_v2.2.1.pdf#page=12).
 
 #### Cloud Registration
 
@@ -71,20 +71,20 @@ hide footbox
 participant D as "Device"
 participant CGW as "CoAP Gateway"
 participant O as "OAuth 2.0 Server"
-participant AS as "Authorization Server"
+participant IS as "Identity Server"
 
 D -> CGW ++: Sign Up
 group OAuth2.0 Authorization Code Grant Flow
     CGW -> O ++: Verify and exchange authorization code for JWT access token
     return Ok\n(JWT Access Token, Refresh Token, ...)
 end
-CGW -> AS ++: Register and assign device to user
+CGW -> IS ++: Register and assign device to user
 return Registered
 return Signed up\n(JWT Access Token, Refresh Token, ...)
 @enduml
 {{< /plantuml >}}
 
-Successful registration to the plgd.dev is followed by authorization request called Sign In. Sign In is required right after successfully established TCP connection to the CoAP Gateway, otherwise the device won't be reachable - marked as online. Other device requests are blocked as well unless the device successfully Signs In. Successful autorization precedes validation of the [JWT Access Token](https://tools.ietf.org/html/rfc6749#section-1.4).
+Successful registration to the plgd.dev is followed by authorization request called Sign In. Sign In is required right after successfully established TCP connection to the CoAP Gateway, otherwise the device won't be reachable - marked as online. Other device requests are blocked as well unless the device successfully Signs In. Successful authorization precedes validation of the [JWT Access Token](https://tools.ietf.org/html/rfc6749#section-1.4).
 
 {{% warning %}}
 Only JWT access tokens are supported on the device.
@@ -99,13 +99,13 @@ hide footbox
 
 participant D as "Device"
 participant CGW as "CoAP Gateway"
-participant AS as "Authorization Server"
+participant IS as "Identity Server"
 participant EB as "Event Bus"
 participant RA as "Resource Aggregate"
 
 D -> CGW ++: Sign In
 CGW -> CGW: Validate JWT Access Token
-CGW -> AS ++: Is device registered?
+CGW -> IS ++: Is device registered?
 return Ok
 CGW -> EB: Subscribe to device & owner events
 CGW -> RA ++: Declare device as online
@@ -115,8 +115,8 @@ return Signed In
 @enduml
 {{< /plantuml >}}
 
-Device capabilities are represented in form of resources. Configuration if the resource is published (remotely accessible over plgd.cloud) or not is part of the [IoTivity-Lite API](https://github.com/iotivity/iotivity-lite/blob/master/include/oc_cloud.h#L128). If the resource is publised or not is up to the device vendor which might want to have some resources accessible only on the proximity network. Resources information which are published to the plgd.cloud provides insights into device capabilities. Clients are interested not only in the resource href - location on which they can request resource representation, but mainly in the resource type as this allows them to filter only capabilities they are able to control.
-As an example, if you have an client application which controls the light, it will search the Resource Directory for all lights user have at home - filter resources by resource type `oic.r.switch.binary`. Other resources like temperature, moisture, etc. are not of any interest, as application doesn't understand their representation.
+Device capabilities are represented in the form of resources. Configuration if the resource is published (remotely accessible over plgd.cloud) or not is part of the [IoTivity-Lite API](https://github.com/iotivity/iotivity-lite/blob/master/include/oc_cloud.h#L128). If the resource is published or not is up to the device vendor, which might want to have some resources accessible only on the proximity network. Resources information which are published to the plgd.cloud provides insights into device capabilities. Clients are interested not only in the resource href - location on which they can request resource representation, but mainly in the resource type, as this allows them to filter only capabilities they are able to control.
+As an example, if you have a client application which controls the light, it will search the Resource Directory for all lights the user has at home - filter resources by resource type `oic.r.switch.binary`. Other resources like temperature, moisture, etc. are not of any interest, as the application doesn't understand their representation.
 Information which is published doesn't contain resource representation, only resource information as described [here (see 6.1.3.2.2)](https://openconnectivity.org/specs/OCF_Device_To_Cloud_Services_Specification_v2.2.0.pdf#page=21).
 
 ```json
@@ -151,10 +151,10 @@ Information which is published doesn't contain resource representation, only res
 }
 ```
 
-Resource publish request is forwarded to the [Resource Aggregate](#resource-aggregate) which registers a new resource. This process makes the resource discoverable.
-The plgd.cloud starts observation of **every successfully published resource** by sending the [OBSERVE request](https://tools.ietf.org/html/rfc7641#section-1.2). Each of the received notification from the device is send to the [Resource Aggregate](#resource-aggregate) to record the change.
+Resource publish request is forwarded to the [Resource Aggregate](#resource-aggregate), which registers a new resource. This process makes the resource discoverable.
+The plgd.cloud starts observation of **every successfully published resource** by sending the [OBSERVE request](https://tools.ietf.org/html/rfc7641#section-1.2). Each of the received notification from the device is sent to the [Resource Aggregate](#resource-aggregate) to record the change.
 
-As the response to the resource observation request contains actual [representation](https://tools.ietf.org/html/rfc7641#section-1.1), CoAP Gateway doesn't have to pull the data at all. Additional responses called [notifications](https://tools.ietf.org/html/rfc7641#section-3.2) are by the device send whenever the representation of the device changes.
+As the response to the resource observation request contains actual [representation](https://tools.ietf.org/html/rfc7641#section-1.1), CoAP Gateway doesn't have to pull the data at all. Additional responses called [notifications](https://tools.ietf.org/html/rfc7641#section-3.2) are sent by the device  whenever the representation of the device changes.
 
 #### Resource Publish & Subscription
 
@@ -184,8 +184,8 @@ CGW -> RA ++: Update resource representation
 return
 @enduml
 {{< /plantuml >}}
-MD013
-From this moment on, device is reachable to all authorized clients and devices. Resource update requests received by particular Gateway where the client is connected are forwarded to the [Resource Aggregate](#resource-aggregate). Successful command validation precede storing and publishing of this event to the [Event Bus](#event-bus), to which is the CoAP Gateway subscribed. If the update request event targets the device hosted by this instance of the CoAP Gateway, [UPDATE](https://tools.ietf.org/html/rfc7252#section-5.8.2) is forwarded over the authorized TCP channel to the device. Device response is forwarded to the [Resource Aggregate](#resource-aggregate) which issues resource updated event updating the resource projection and informing client that the update was successful.
+
+From this moment on, the device is reachable to all authorized clients and devices. Resource update requests received by a particular Gateway where the client is connected are forwarded to the [Resource Aggregate](#resource-aggregate). Successful command validation precede storing and publishing of this event to the [Event Bus](#event-bus), to which is the CoAP Gateway subscribed. If the update request event targets the device hosted by this instance of the CoAP Gateway, [UPDATE](https://tools.ietf.org/html/rfc7252#section-5.8.2) is forwarded over the authorized TCP channel to the device. The device response is forwarded to the [Resource Aggregate](#resource-aggregate), which issues a resource updated event, updating the resource projection and informing the client that the update was successful.
 
 #### Resource Update
 
@@ -238,7 +238,7 @@ Device is at this point requested to disconnect from the plgd Cloud from the loc
 
 ##### Force disconnect by the plgd Cloud
 
-User might decide to delete the device directly using the plgd API. This approach is handy when it comes to stale devices, which cannot be anymore requested by the Onboarding Tool to disconnect and you want to cleanup your list of devices in the plgd Cloud.
+User might decide to delete the device directly using the plgd API. This approach is handy when it comes to stale devices, which cannot be any more requested by the Onboarding Tool to disconnect, and you want to clean up your list of devices in the plgd Cloud.
 
 {{< plantuml id="device-delete" >}}
 @startuml
@@ -248,7 +248,7 @@ hide footbox
 participant C as "Client"
 participant GGW as "gRPC Gateway"
 participant RA as "Resource Aggregate"
-participant AS as "Authorization Server"
+participant IS as "Identity Server"
 participant EB as "Event Bus"
 participant CGW as "CoAP Gateway"
 participant D as "Device"
@@ -256,9 +256,9 @@ participant D as "Device"
 C -> GGW ++: DeleteDevicesRequest
 GGW -> RA ++: DeleteDevicesRequest
 return DeleteDevicesResponse
-GGW -> AS ++: DeleteDevicesRequest
+GGW -> IS ++: DeleteDevicesRequest
 return DeleteDevicesResponse
-AS --> EB: DevicesDeleted
+IS --> EB: DevicesDeleted
 return DeleteDevicesResponse
 EB --> CGW: DevicesDeleted
 CGW -> D: Disconnect
@@ -266,7 +266,7 @@ destroy D
 
 D -> CGW ++: Sign In
 CGW -> CGW: Validate JWT Access Token
-CGW -> AS ++: Is device registered?
+CGW -> IS ++: Is device registered?
 return Not registered
 note right
   Revoke Refresh Token
@@ -289,9 +289,9 @@ D -> D: Cleanup cloud configuration
 
 ## Resource Aggregate
 
-Every transaction on the device's resource is scoped to the single [aggregate](https://martinfowler.com/bliki/DDD_Aggregate.html) - Resource Aggregate. The RA builds it's internal state, which is a projection of a single fine-grained event stream. When the aggregate receives a new command from any of the plgd gateway, the command is validated and after successful validation event describing the action is created and persisted in the [EventStore](#event-store). After successful write to the [EventStore](#event-store), event is published to the [EventBus](#event-bus).
+Every transaction on the device's resource is scoped to the single [aggregate](https://martinfowler.com/bliki/DDD_Aggregate.html) - Resource Aggregate. The RA builds its internal state, which is a projection of a single fine-grained event stream. When the aggregate receives a new command from any of the plgd gateways, the command is validated and after successful validation event describing the action is created and persisted in the [EventStore](#event-store). After successful write to the [EventStore](#event-store), the event is published to the [EventBus](#event-bus).
 
-> To prevent the conflicts during the write to EventStore, [Optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) method is used
+> To prevent the conflicts during the write to EventStore, [Optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) method is used.
 
 ### Commands and Events Overview
 
@@ -405,10 +405,10 @@ plgd cloud uses [NATS](https://nats.io) messaging system as it's event bus.
 
 ## Event Store
 
-plgd cloud persist events in an event store, which is a database of events. The store has an API for adding and retrieving device's events. Events needs to be versioned and written in a correct order. To achieve the consistency, optimistic concurrency control method is applied during each write.
-After the event is successfully written into the event store, it's distributed to the event bus which notifies all subscribers about the change asynchronously.
+plgd cloud persist events in an event store, which is a database of events. The store has an API for adding and retrieving device's events. Events need to be versioned and written in a correct order. To achieve the consistency, optimistic concurrency control method is applied during each write.
+After the event is successfully written into the event store, it's distributed to the event bus, which notifies all subscribers about the change asynchronously.
 
-The plgd cloud defines an [EventStore](https://github.com/plgd-dev/cloud/blob/v2/resource-aggregate/cqrs/eventstore/eventstore.go#L23) interface what allows integration of different technologies to store the events. During the last 2 years the project evaluated multiple technologies for both EventStore and EventBus:
+The plgd cloud defines an [EventStore](https://github.com/plgd-dev/cloud/blob/v2/resource-aggregate/cqrs/eventstore/eventstore.go#L23) interface what allows integration of different technologies to store the events. During the last 2 years, the project evaluated multiple technologies for both EventStore and EventBus:
 
 - CockroachDB
 - Apache Kafka
@@ -418,7 +418,7 @@ The plgd cloud defines an [EventStore](https://github.com/plgd-dev/cloud/blob/v2
 - Amazon Kinesis
 
 {{% note %}}
-Currently supported and preffered solution is MongoDB. Read further to know more about the database scheme and how we are Event Sourcing!
+Currently, supported and preferred solution is MongoDB. Read further to know more about the database scheme and how we are Event Sourcing!
 {{% /note %}}
 
 ### MongoDB
@@ -442,7 +442,7 @@ This model is now being evaluated by the MondoDB team and is likely to be improv
 
 1. Get latest snapshot
     a. Find document `where _id == B.s`
-    b. Get `version` of latest snapshot event
+    b. Get `version` of the latest snapshot event
 2. Find documents `where aggregateID == B && version >= latestSnapshot.version`
 
 - Details Query all resources of device d9dd7...

--- a/content/en/developer-guide/advanced-security.md
+++ b/content/en/developer-guide/advanced-security.md
@@ -15,7 +15,7 @@ toc: true
 
 ## Setup mutual TLS
 
-At coap-gateway you can setup mutual TLS, which verify the signature of the identity certificate of the device via configuration:
+At coap-gateway you can set up mutual TLS, which verify the signature of the identity certificate of the device via configuration:
 
 ```yaml
 api:
@@ -25,23 +25,23 @@ api:
       clientCertificateRequired: true
 ```
 
-After that only devices which have signed identity certificates by CA configured in coap-gateway can access the cloud.
+After that, only devices which have signed identity certificates by CA configured in coap-gateway can access the cloud.
 
 ## How coap-gateway resolves device ID
 
 When the device makes one of the calls sign up, sign in, sign out or sign off, coap-gateway needs to resolve the device ID.
 
-1. If coap-gateway has set `api.coap.authorization.deviceIdClaim` then it will be resolved from JWT token. If JWT token doesn't contain `https://<YOUR_DOMAIN>/deviceId` it returns code `Unauthorized` and close the connection.
+1. If coap-gateway has set `api.coap.authorization.deviceIdClaim` then it will be resolved from JWT token. If JWT token doesn't contain `https://<YOUR_DOMAIN>/deviceId` it returns code `Unauthorized` and closes the connection.
 2. If coap-gateway has set mutual TLS `api.coap.tls.clientCertificateRequired` then it will be resolved from the device identity certificate.
-3. If any previous options are set, will be resolved from the request parameter.
+3. If none of the previous options are set, device ID will be resolved from the request parameter.
 
 ## Don't allow access with a token that doesn't bellow the device
 
-When `api.coap.tls.clientCertificateRequired` and `api.coap.authorization.deviceIdClaim` are set, coap-gateway verifies matches deviceID from certificate and JWT token. If they are not same, then coap-gateway returns code `Unauthorized` and closes the connection.
+When `api.coap.tls.clientCertificateRequired` and `api.coap.authorization.deviceIdClaim` are set, coap-gateway matches deviceID from certificate and JWT token. If they are not the same, then coap-gateway returns code `Unauthorized` and closes the connection.
 
 ## How to push deviceId to the token with auth0
 
-At first you need to create a rule at `Auth pipeline->Rules` with code:
+First, you need to create a rule at `Auth pipeline->Rules` with code:
 
 ```js
 function (user, context, callback) {
@@ -57,4 +57,4 @@ function (user, context, callback) {
 After that, if you call authorize endpoint to obtain authorization code for a device with query parameter `deviceId=<device id>`,
 and the device makes sign up with that code, the returned JWT access token will contain deviceId claim like `https://<YOUR_DOMAIN>/deviceId: <deviceId>`.
 
-For validation device id claim by coap-gateway, the `api.coap.authorization.deviceIdClaim` need to be set  to `https://<YOUR_DOMAIN>/deviceId`.
+For validation of device ID claim by coap-gateway the `api.coap.authorization.deviceIdClaim` must be set to `https://<YOUR_DOMAIN>/deviceId`.

--- a/content/en/quickstart/deploy-plgd-cloud.md
+++ b/content/en/quickstart/deploy-plgd-cloud.md
@@ -39,7 +39,7 @@ After couple of seconds your plgd cloud will become available. The plgd dashboar
 
 ### Authorization
 
-The plgd cloud doesn't work without OAuth Server. To not require developers not interested in sharing bundle instance with other users, simple mocked OAuth Server is included in the bundle. Authentication to the plgd is therefore not required and test user is automatically logged in. Same applies also to device connections; in case you're using the bundle, devices connecting to the CoAP Gateway can use random/static onboarding code as it's not verified. Onboarding of devices is therefore much simpler.
+The plgd cloud doesn't work without OAuth Server. To not require developers not interested in sharing bundle instances with other users, a simple mocked OAuth Server is included in the bundle. Authentication to the plgd is therefore not required, and the test user is automatically logged in. The same applies also to device connections; in case you're using the bundle, devices connecting to the CoAP Gateway can use random/static onboarding code as it's not verified. Onboarding of devices is therefore much simpler.
 
 {{% warning %}}
 Authorization Service which is part of the plgd is only for testing and development purposes. For the production, integration of the plgd device identity management API is required.
@@ -49,7 +49,7 @@ Even for the development and testing, more complex scenarios are supported by th
 
 ### Troubleshooting
 
-- By default the plgd cloud bundle hosts the NGINX proxy on port `443`. This port might be already occupied by other process, e.g. Skype. Default port can be changed by environment variable `-e NGINX_PORT=8443`. Please be aware that the port needs to be exposed from the container -> `-p 443:443` needs to be changed to match a new port, e.g. `-p 8443:8443`.
+- By default, the plgd cloud bundle hosts the NGINX proxy on port `443`. This port might be already occupied by other process, e.g. Skype. Default port can be changed by environment variable `-e NGINX_PORT=8443`. Please be aware that the port needs to be exposed from the container -> `-p 443:443` needs to be changed to match a new port, e.g. `-p 8443:8443`.
 - Logs and data are by default stored at `/data` path. Run the container with `-v $PWD/vol/plgd/data:/data` to be able to analyze the logs in case of an issue.
 - In case you need support, we are happy to support you on [Gitter](http://gitter.im/ocfcloud/Lobby)
 - OCF UCI (Cloud2Cloud Gateway) is not part of the bundle

--- a/content/en/tutorials/external-oauth-server.md
+++ b/content/en/tutorials/external-oauth-server.md
@@ -13,24 +13,19 @@ toc: true
 ---
 
 Even though the bundle start core plgd services as processes in a single container, a user has still a possibility to configure most of the services parameters. **For testing purposes**, the external OAuth Server (e.g. [Auth0](https://auth0.com)) can be set up.
-To skip internal mocked OAuth Server and switch to your external one, configure following environment variables:
+To skip the internal mocked OAuth Server and switch to your external one, configure the following environment variables:
 
 ```yaml
     OAUTH_AUDIENCE: https://api.example.com
-    OAUTH_ENDPOINT_AUTH_URL: https://auth.example.com/authorize
-    OAUTH_ENDPOINT_TOKEN_URL: https://auth.example.com/oauth/token
     OAUTH_ENDPOINT: auth.example.com
-    JWKS_URL: https://auth.example.com/.well-known/jwks.json
     OAUTH_CLIENT_ID: ij12OJj2J23K8KJs
     OAUTH_CLIENT_SECRET: 654hkja12asd123d
-    SERVICE_OAUTH_CLIENT_ID: 412dsFf53Sj6$
-    SERVICE_OAUTH_CLIENT_SECRET: 235Jgdf65jsd4Shls
     OWNER_CLAIM: sub
 ```
 
 ## How to configure Auth0
 
-Assuming you have an account in the Auth0 OAuth as a service, you need to create 2 Applications and one API. Follow these steps to successfully configure bundle to run against your Auth0 instance.
+Assuming you have an account in the Auth0 OAuth as a service, you need to create 2 Applications and one API. Follow these steps to successfully configure the bundle to run against your Auth0 instance.
 
 1. Create new **API** in the APIs section
     1. Use name of your choice

--- a/content/en/tutorials/shared-ownership.md
+++ b/content/en/tutorials/shared-ownership.md
@@ -12,7 +12,7 @@ menu:
 toc: true
 ---
 
-Devices are in the authorization service organized by the owner ID retrieved from the JWT token. The plgd API will based on this value identify the user and grant him the permission only to devices he owns. By default, JWT claim `sub` is used as the owner ID. In case you connect the plgd authorization service with the Auth0, each logged-in user can access only his devices. This behaviour can be changed by changing the `OWNER_CLAIM` configuration property and adding custom claim to your Auth0 users.
+Devices are organized in the identity service by the owner ID retrieved from the JWT token. The plgd API will be based on this value to identify the user and grant him the permissions only to devices he owns. By default, JWT claim `sub` is used as the owner ID. In case you connect the plgd authorization service with the Auth0, each logged-in user can access only his devices. This behaviour can be changed by changing the `OWNER_CLAIM` configuration property and adding custom claim to your Auth0 users.
 
 ## How to use custom claim with Auth0
 
@@ -39,7 +39,7 @@ Devices are in the authorization service organized by the owner ID retrieved fro
 ### Include custom claim to access token
 
 1. Go to **Rules** and create new one
-1. Copy paste the function below which uses custom claim `https://plgd.dev/tenant`
+1. Copy and paste the function below, which uses custom claim `https://plgd.dev/tenant`
 
     ```js
     function addTenantToAccessToken(user, context, callback) {
@@ -53,7 +53,7 @@ Devices are in the authorization service organized by the owner ID retrieved fro
     }
     ```
 
-After the rule is created, Auth0 include into every access tokens custom claim `https://plgd.dev/tenant` used to group users and "their" devices. In case the custom `OWNER_CLAIM` is configured, devices are no more owned by a single user, but in this case, by the **tenant**. Each user who is member of the tenant A will be able to access all the devices of this tenant.
+After the rule is created, Auth0 include into every access tokens custom claim `https://plgd.dev/tenant` used to group users and "their" devices. In case the custom `OWNER_CLAIM` is configured, devices are no more owned by a single user, but in this case, by the **tenant**. Each user who is a member of the tenant A will be able to access all the devices of this tenant.
 
 {{% warning %}}
 If the configuration property `OWNER_CLAIM` is changed, each user is required to have this claim present.

--- a/content/en/tutorials/working-with-grpc-client.md
+++ b/content/en/tutorials/working-with-grpc-client.md
@@ -41,11 +41,11 @@ import (
 
 ## Using extended gRPC Client
 
-More info in [doc](https://pkg.go.dev/github.com/plgd-dev/cloud/grpc-gateway/client)
+More info in [doc](https://pkg.go.dev/github.com/plgd-dev/cloud/grpc-gateway/client).
 
 ## API
 
-All requests to service must contains valid access token in [grpc metadata](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-auth-support.md#oauth2).
+All requests to the service must contain a valid access token in the [grpc metadata](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-auth-support.md#oauth2).
 
 {{% warning %}}
 Each request to the gRPC Gateway shall contain a valid access token as a part of the [grpc metadata](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-auth-support.md#oauth2).
@@ -61,7 +61,7 @@ The `GetDevices` command supports various filter options. If all of them are **u
 - to retrieve all offline devices set `GetDevicesRequest.status_filter` to `OFFLINE`
 - to retrieve all devices of certain types use `GetDevicesRequest.type_filter` (e.g. `x.com.plgd.light`)
 
-To return only `ONLINE` devices with ids `deviceID1` and `deviceID2`, following options shall be set: `GetDevicesRequest.device_id_filter("[deviceID1, deviceID2]") && GetDevicesRequest.status_filter([ONLINE])`.
+To return only `ONLINE` devices with ids `deviceID1` and `deviceID2`, the following options shall be set: `GetDevicesRequest.device_id_filter("[deviceID1, deviceID2]") && GetDevicesRequest.status_filter([ONLINE])`.
 
 ### Get Resource Links
 
@@ -72,7 +72,7 @@ The `GetResourceLinks` command supports various filter options. If all of them a
 - to retrieve links of certain devices use `GetResourceLinksRequest.device_id_filter` where ids of these devices needs to be set
 - to retrieve links of certain types use `GetResourceLinksRequest.type_filter` (e.g. `oic.r.switch.binary`)
 
-To return only binary switches resources hosted by devices with ids `deviceID1` and `deviceID2`, following options shall be set: `GetResourceLinksRequest.device_id_filter("[deviceID1, deviceID2]") && GetResourceLinksRequest.type_filter([oic.r.switch.binary])`.
+To return only binary switches resources hosted by devices with ids `deviceID1` and `deviceID2`, the following options shall be set: `GetResourceLinksRequest.device_id_filter("[deviceID1, deviceID2]") && GetResourceLinksRequest.type_filter([oic.r.switch.binary])`.
 
 ### Get Resource Content
 
@@ -88,16 +88,16 @@ To return values of binary switch resources hosted by devices with ids `deviceID
 
 ### Subscribe to Events
 
-The `SubscribeToEvents` command opens the stream which content is driven by the control message.
+The `SubscribeToEvents` command opens the stream, which content is driven by the control message.
 
-**To control content of the stream, send a `SubscribeToEvents` message with following options:**
+**To control the content of the stream, send a `SubscribeToEvents` message with the following options:**
 
-- `action.create_subscription.event_filter` set to e.g. `ONLINE` to receive **devices events** which changed their status to `ONLINE`
-- `action.create_subscription.{device_id_filter, event_filter}` set to e.g. `RESOURCE_PUBLISHED` to receive **device events**
-- `action.create_subscription.{resource_id_filter, event_filter}` set to e.g. `CONTENT_CHANGED` to receive **resource events**
+- `action.create_subscription.event_filter` set to `ONLINE` to receive **devices events** which changed their status to `ONLINE`
+- `action.create_subscription.{device_id_filter, event_filter}` set to `RESOURCE_PUBLISHED` to receive **device events**
+- `action.create_subscription.{resource_id_filter, event_filter}` set to `CONTENT_CHANGED` to receive **resource events**
 - `action.create_subscription` without any set of filters will receive all devices events from the cloud.
 
-The first event returned after the successful subscription is of type `OperationProcessed`. Property `OperationProcessed.error_status.code` contains information if the subscription was successful. If it was successful, property `subscriptionId` is set. All events belonging to single `SubscribeToEvents` request are then identified by this `subscriptionId`.
+The first event returned after the successful subscription is of type `OperationProcessed`. Property `OperationProcessed.error_status.code` contains information if the subscription was successful. If it was successful, property `subscriptionId` is set. All events belonging to a single `SubscribeToEvents` request are then identified by this `subscriptionId`.
 
 If the user loses a device _(unregistered / no more shared with the user)_, the client receives an event `SubscriptionCanceled` with corresponding `subscription_id`.
 
@@ -116,11 +116,11 @@ The `Create Resource` command requests the creation of a new resource on a speci
 
 ### Delete Resource
 
-The `DeleteResource` command requests the device to delete a specific resource. A confirmation message doesn't mean that the resource was deleted. After successful deletion, the device unpublishes its resource. This information is propagated to the client in form of a `RESOURCE_UNPUBLISHED` event. To define the expiration of command, set `DeleteResourceRequest.time_to_live` in nanoseconds(minimal 100ms). If the pending event is expired `ResourceDeletePending.valid_until` (Unix timestamp in nanoseconds, 0 means forever), the cloud skips it and will be removed by creating a new snapshot event.
+The `DeleteResource` command requests the device to delete a specific resource. A confirmation message doesn't mean that the resource was deleted. After successful deletion, the device unpublishes its resource. This information is propagated to the client in the form of a `RESOURCE_UNPUBLISHED` event. To define the expiration of command, set `DeleteResourceRequest.time_to_live` in nanoseconds(minimal 100ms). If the pending event is expired `ResourceDeletePending.valid_until` (Unix timestamp in nanoseconds, 0 means forever), the cloud skips it and will be removed by creating a new snapshot event.
 
 ### Get pending commands
 
-The `GetPendingCommands` command supports various filter options. If all of them are **unset**, all pending commands of all devices user is authorized to use are returned.
+The `GetPendingCommands` command supports various filter options. If all of them are **unset**, all pending commands of all devices the user is authorized to use are returned.
 
 **Example usages of filter options:**
 
@@ -133,7 +133,7 @@ To return certain pending commands of binary switch resources hosted by devices 
 
 ### Get devices metadata
 
-The `GetDevicesMetadata` command supports various filter options. If all of them are **unset**, all metadata of all devices user is authorized to use are returned. Metadata contains information about connection status(ONLINE/OFFLINE) and shadow synchronization(ENABLED, DISABLED)
+The `GetDevicesMetadata` command supports various filter options. If all of them are **unset**, all metadata of all devices the user is authorized to use are returned. Metadata contains information about connection status(ONLINE/OFFLINE) and shadow synchronization(ENABLED, DISABLED)
 
 **Example usages of filter options:**
 
@@ -156,12 +156,12 @@ The `GetEvents` command returns events that occurred on a resource. The command 
 
 ### Delete devices
 
-The `DeleteDevices` command requests delete entries of selected devices in authorization and events databases. The command supports filtering by setting `deviceIdFilter` value. List of deleted device ids is returned in the response.
+The `DeleteDevices` command requests to delete entries of selected devices in the identity and events databases. The command supports filtering by setting `deviceIdFilter` value. A list of deleted device ids is returned in the response.
 
 **Example usages of filter options:**
 
 - to delete entries for devices owned by the user with ids `deviceID1` and `deviceID2` use `DeleteDevicesRequest.device_id_filter("[deviceID1, deviceID2]")`.
-- to delete entries for all devices owned by the user use `DeleteDevicesRequest` with empty `device_id_filter`.
+- to delete entries for all devices owned by the user, use `DeleteDevicesRequest` with empty `device_id_filter`.
 
 ### Cancel pending commands
 


### PR DESCRIPTION
- rename authorization (server) to identity (server) where relevant
- fix some grammar errors reported by LanguageTool